### PR TITLE
bump bundle version

### DIFF
--- a/Packages/rt.xr.maf/package.json
+++ b/Packages/rt.xr.maf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rt.xr.maf",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "A C++ implementation of the Media Access Function API specified by in ISOIEC 23090-14.",
     "displayName": "rt.xr.maf",
     "unity": "2022.3",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -139,7 +139,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.0.0
+  bundleVersion: 1.1.0
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 11400000, guid: aea5e8e3658f9454385f4e61a6ef7f46, type: 2}
@@ -664,7 +664,7 @@ PlayerSettings:
   webGLPowerPreference: 2
   scriptingDefineSymbols:
     Android: USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS;STEAMAUDIO_ENABLED
-    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS;STEAMAUDIO_ENABLED
+    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS;STEAMAUDIO_ENABLED;ARCORE_USE_ARF_5
     WebGL: STEAMAUDIO_ENABLED
     Windows Store Apps: USE_INPUT_SYSTEM_POSE_CONTROL;USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS
     iPhone: STEAMAUDIO_ENABLED


### PR DESCRIPTION
- bump bundle version in unity project settings.
- bump rt.xr.maf's Package version to track source's latest tag.